### PR TITLE
Fix TypeError from got while getting tvdbapi token

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,9 +21,9 @@ Images.init = function(trakt, opts) {
                 'content-type': 'application/json'
             },
             method: 'POST',
-            body: JSON.stringify({
+            body: {
                 apikey: opts.tvdbApiKey
-            })
+            }
         }).then(function(res) {
             if (res.body && res.body.token) {
                 TvdbApiKey = res.body.token;


### PR DESCRIPTION
TypeError: options.body must be a plain Object or Array when options.form or options.json is used

Error while getting tvdbApi token.